### PR TITLE
Jenkins update, target endpoint update and https maven repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.150.1
+FROM jenkins/jenkins:2.150.3
 
 # install jenkins plugins
 COPY --chown=jenkins:jenkins ./docker/jenkins/plugins /usr/share/jenkins/plugins

--- a/currency-v1/apiproxy/targets/default.xml
+++ b/currency-v1/apiproxy/targets/default.xml
@@ -56,7 +56,7 @@
 	</PostFlow>
 
 	<HTTPTargetConnection>
-		<URL>https://frankfurter.app</URL>
+		<URL>https://api.frankfurter.app</URL>
 	</HTTPTargetConnection>
 
 </TargetEndpoint>

--- a/currency-v1/pom.xml
+++ b/currency-v1/pom.xml
@@ -12,7 +12,7 @@
 		<pluginRepository>
 			<id>central</id>
 			<name>Maven Plugin Repository</name>
-			<url>http://repo1.maven.org/maven2</url>
+			<url>https://repo1.maven.org/maven2</url>
 			<layout>default</layout>
 			<snapshots>
 				<enabled>false</enabled>


### PR DESCRIPTION
I have encountered a few problems during my deployment.
Jenkins version had to be updated since one the plugins required it.
Maven had to use https repo again due to a maven plugin.
finally target endpoint has changed.